### PR TITLE
Update Discrete & Empty Relation Definitions

### DIFF
--- a/book/ch05-relations/s1-relations.tex
+++ b/book/ch05-relations/s1-relations.tex
@@ -110,9 +110,9 @@ Let $f : X \to Y$ be a function, and define the relation $R_f$ from $X$ to $Y$ a
 \index{discrete relation}
 \index{relation!empty}
 \index{relation!discrete}
-The \textbf{discrete relation} from a set $X$ to a set $Y$ is the relation $D_{X,Y}$ defined by letting $x \mathrel{D_{X,Y}} y$ be true for all $x,y \in X$.
+The \textbf{discrete relation} from a set $X$ to a set $Y$ is the relation $D_{X,Y}$ defined by letting $x \mathrel{D_{X,Y}} y$ be true for all $x \in X, y \in Y$.
 
-The \textbf{empty relation} from a set $X$ to a set $Y$ is the relation $\varnothing_{X,Y}$\nindex{OXY}{$\varnothing_{X,Y}$}{empty relation} \inlatex{varnothing} defined by letting $x \mathrel{\varnothing_{X,Y}} y$ be false for all $x,y \in X$.
+The \textbf{empty relation} from a set $X$ to a set $Y$ is the relation $\varnothing_{X,Y}$\nindex{OXY}{$\varnothing_{X,Y}$}{empty relation} \inlatex{varnothing} defined by letting $x \mathrel{\varnothing_{X,Y}} y$ be false for all $x \in X, y \in Y$.
 \end{definition}
 
 \begin{exercise}


### PR DESCRIPTION
The definition referred to elements x and y both being members of set X, when the relation was from from set X to set Y. Updated y to be drawn from set Y instead.