### PR TITLE
Removed seemingly extraneous line

### DIFF
--- a/book/ch06-number-theory/s1-divisibility.tex
+++ b/book/ch06-number-theory/s1-divisibility.tex
@@ -171,7 +171,7 @@ By the well-ordering principle, $X$ has a least element $d$, and by definition o
 We will prove that $d$ is a greatest common divisor for $a$ and $b$.
 \begin{itemize}
 \item $d \mid a$. If $a=0$, then this is immediate, so suppose that $a > 0$. Let $q,r \in \mathbb{Z}$ be such that \[ a=qd+r \qquad \text{and} \qquad 0 \le r < d \]
-Now $a = a \cdot 1 + b \cdot 0$, so $a \in X$, and hence $d \le a$. Moreover
+Moreover
 \[ r = a-qd = a-q(au+bv) = a(1-qu) + b(-qv) \]
 If $r>0$ then this implies that $r \in X$; but this would contradict minimality of $d$, since $r < d$. So we must have $r=0$ after all.
 \item $d \mid b$. The proof of this is identical to the proof that $d \mid a$.


### PR DESCRIPTION
The proof that d divides a relies on the remainder as given by the Division Theorem being 0 to satisfy the definition of "divides" given above. This does not require any assumptions or comparisons between d and a, and the note that d is less than or equal to a thus appears extraneous and distracts from the flow of the proof (as does the noting of the relatively trivial point that a is in the set X).