### PR TITLE
Wrong strategy used

### DIFF
--- a/book/ch01-logical-structure/s1-propositional-logic.tex
+++ b/book/ch01-logical-structure/s1-propositional-logic.tex
@@ -503,7 +503,7 @@ Let $n$ be a positive proper factor of $4$, and suppose we want to prove that $n
 \item Our goal is to prove the disjunction `$n \text{ is even} \vee n \text{ is a perfect square}$'.
 \end{itemize}
 
-According to \Cref{strAssumingConjunctionsDirect}, we split into two cases, one in which $n=1$ and one in which $n=2$. In each case, we must derive `$n \text{ is even} \vee n \text{ is a perfect square}$', for which it suffices by \Cref{strProvingDisjunctionsDirect} to derive either that $n$ is even or that $n$ is a perfect square. Thus a proof might look something like this:
+According to \Cref{strAssumingDisjunctionsDirect}, we split into two cases, one in which $n=1$ and one in which $n=2$. In each case, we must derive `$n \text{ is even} \vee n \text{ is a perfect square}$', for which it suffices by \Cref{strProvingDisjunctionsDirect} to derive either that $n$ is even or that $n$ is a perfect square. Thus a proof might look something like this:
 
 \begin{quote}
 Since $n$ is a positive proper factor of $4$, either $n=1$ or $n=2$.


### PR DESCRIPTION
It appears that strategy 1.1.9 was used instead of 1.1.16.